### PR TITLE
Allow sanitizing arrays of all types while preserving primitive values

### DIFF
--- a/src/main/java/com/paypal/heapdumptool/sanitizer/HeapDumpSanitizer.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/HeapDumpSanitizer.java
@@ -50,6 +50,7 @@ public class HeapDumpSanitizer {
     private OutputStream outputStream;
     private ProgressMonitor progressMonitor;
     private String sanitizationText;
+    private boolean sanitizeArraysOnly;
     private boolean sanitizeByteCharArraysOnly;
 
     public void setInputStream(final InputStream inputStream) {
@@ -68,8 +69,18 @@ public class HeapDumpSanitizer {
         this.sanitizationText = sanitizationText;
     }
 
-    public void setSanitizeByteCharArraysOnly(final boolean sanitizeArraysOnly) {
-        this.sanitizeByteCharArraysOnly = sanitizeArraysOnly;
+    public void setSanitizeArraysOnly(final boolean sanitizeArraysOnly) {
+        if (sanitizeArraysOnly && sanitizeByteCharArraysOnly) {
+            throw new IllegalArgumentException("sanitizeArraysOnly and sanitizeByteCharArraysOnly cannot be both set to true simultaneously");
+        }
+        this.sanitizeArraysOnly = sanitizeArraysOnly;
+    }
+
+    public void setSanitizeByteCharArraysOnly(final boolean sanitizeByteCharArraysOnly) {
+        if (sanitizeArraysOnly && sanitizeByteCharArraysOnly) {
+            throw new IllegalArgumentException("sanitizeArraysOnly and sanitizeByteCharArraysOnly cannot be both set to true simultaneously");
+        }
+        this.sanitizeByteCharArraysOnly = sanitizeByteCharArraysOnly;
     }
 
     public void sanitize() throws IOException {
@@ -216,7 +227,7 @@ public class HeapDumpSanitizer {
 
     private void pipeStaticField(final Pipe pipe, final int entryType) throws IOException {
         final int valueSize = BasicType.findValueSize(entryType, pipe.getIdSize());
-        if (enableSanitization && !sanitizeByteCharArraysOnly) {
+        if (enableSanitization && !sanitizeByteCharArraysOnly && !sanitizeArraysOnly) {
             applySanitization(pipe, valueSize);
         } else {
             pipe.pipe(valueSize);
@@ -242,7 +253,7 @@ public class HeapDumpSanitizer {
         pipe.pipeU4();
         pipe.pipeId();
         final long numBytes = pipe.pipeU4();
-        if (enableSanitization && !sanitizeByteCharArraysOnly) {
+        if (enableSanitization && !sanitizeByteCharArraysOnly && !sanitizeArraysOnly) {
             applySanitization(pipe, numBytes);
         } else {
             pipe.pipe(numBytes);

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeCommand.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeCommand.java
@@ -41,6 +41,9 @@ public class SanitizeCommand implements CliCommand {
     @Option(names = {"-s", "--sanitize-byte-char-arrays-only"}, description = "Sanitize byte/char arrays only", defaultValue = "true", showDefaultValue = ALWAYS)
     private boolean sanitizeByteCharArraysOnly = true;
 
+    @Option(names = {"--sanitize-arrays-only"}, description = "Sanitize arrays only", defaultValue = "false", showDefaultValue = ALWAYS)
+    private boolean sanitizeArraysOnly;
+
     @Option(names = {"-b", "--buffer-size"}, description = "Buffer size for reading and writing", defaultValue = "100MB", showDefaultValue = ALWAYS)
     private DataSize bufferSize = ofMegabytes(100);
 
@@ -63,6 +66,14 @@ public class SanitizeCommand implements CliCommand {
 
     public void setSanitizeByteCharArraysOnly(final boolean sanitizeByteCharArraysOnly) {
         this.sanitizeByteCharArraysOnly = sanitizeByteCharArraysOnly;
+    }
+
+    public boolean isSanitizeArraysOnly() {
+        return sanitizeArraysOnly;
+    }
+
+    public void setSanitizeArraysOnly(boolean sanitizeArraysOnly) {
+        this.sanitizeArraysOnly = sanitizeArraysOnly;
     }
 
     public Path getInputFile() {

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeCommandProcessor.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeCommandProcessor.java
@@ -52,6 +52,7 @@ public class SanitizeCommandProcessor implements CliCommandProcessor {
             sanitizer.setProgressMonitor(numBytesProcessedMonitor(command.getBufferSize(), LOGGER));
             sanitizer.setSanitizationText(command.getSanitizationText());
             sanitizer.setSanitizeByteCharArraysOnly(command.isSanitizeByteCharArraysOnly());
+            sanitizer.setSanitizeArraysOnly(command.isSanitizeArraysOnly());
 
             sanitizer.sanitize();
         }


### PR DESCRIPTION
The sanitizeByteCharArraysOnly allows to apply sanitation to byte[] and char[] arrays only. However in certain cases other type of arrays may also contain data needed to be sanitized. The new flag allows enabling sanitation for all arrays while keeping the primitive values (fields, stack values) untouched.