### PR TITLE
Force "coder" field value in string instances to match sanitizationText's coder value.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21' ]
+        java: [ '8', '11', '17', '21', '23' ]
 
     name: Java ${{ matrix.Java }}
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ Plain thread dump is also captured
                           Default: 100MB
   -d, --docker-registry=<dockerRegistry>
                         docker registry hostname for bootstrapping heap-dump-tool docker image
+  -f, --force-string-coder-match
+                     Force strings coder values to match sanitizationText.coder value
+                       Default: true
   -p, --pid=<pid>       Pid within the container, if there are multiple Java processes
   -s, --sanitize-byte-char-arrays-only
                         Sanitize byte/char arrays only

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
-        <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+        <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
@@ -40,7 +40,7 @@
         <!-- Specify all SonarQube code coverage reports - default does not pick up integration tests -->
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
-        <slf4j.version>2.0.16</slf4j.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <spring-boot.version>2.7.18</spring-boot.version>
         <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
 

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/BasicType.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/BasicType.java
@@ -27,7 +27,7 @@ public enum BasicType {
                      .findFirst();
     }
 
-    private BasicType(final int u1Code) {
+    BasicType(final int u1Code) {
         this.u1Code = u1Code;
     }
 
@@ -35,7 +35,7 @@ public enum BasicType {
         return u1Code;
     }
 
-    private int getValueSize(final int idSize) {
+    public int getValueSize(final int idSize) {
         switch (this) {
             case OBJECT:
                 return idSize;

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/Field.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/Field.java
@@ -1,0 +1,28 @@
+package com.paypal.heapdumptool.sanitizer;
+
+public class Field {
+
+    private final String fieldName;
+    private final BasicType fieldType;
+
+    public Field(final String fieldName, final BasicType fieldType) {
+        this.fieldName = fieldName;
+        this.fieldType = fieldType;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public BasicType getFieldType() {
+        return fieldType;
+    }
+
+    @Override
+    public String toString() {
+        return "Field{" +
+                "fieldName='" + fieldName + '\'' +
+                ", fieldType=" + fieldType +
+                '}';
+    }
+}

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/HeapDumpSanitizer.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/HeapDumpSanitizer.java
@@ -53,7 +53,6 @@ public class HeapDumpSanitizer {
     // for debugging/testing
     private static final boolean enableSanitization = isFalse(Boolean.getBoolean("disable-sanitization"));
 
-
     private InputStream inputStream;
     private OutputStream outputStream;
     private ProgressMonitor progressMonitor;
@@ -63,7 +62,6 @@ public class HeapDumpSanitizer {
     private Map<Long, Long> classObjectIdToStringIdMap = new HashMap<>();
     private final List<Field> stringInstanceFields = new ArrayList<>();
     private Long stringClassObjectId;
-    private Byte sanitizationTextCoder;
 
     public void setInputStream(final InputStream inputStream) {
         this.inputStream = inputStream;

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/HeapDumpSanitizer.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/HeapDumpSanitizer.java
@@ -3,14 +3,23 @@ package com.paypal.heapdumptool.sanitizer;
 import com.paypal.heapdumptool.utils.InternalLogger;
 import com.paypal.heapdumptool.utils.ProgressMonitor;
 import org.apache.commons.io.input.InfiniteCircularInputStream;
-import org.apache.commons.lang3.Validate;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
+import static com.paypal.heapdumptool.sanitizer.HeapRecord.HEAP_DUMP;
+import static com.paypal.heapdumptool.sanitizer.HeapRecord.HEAP_DUMP_SEGMENT;
+import static com.paypal.heapdumptool.sanitizer.HeapRecord.LOAD_CLASS;
+import static com.paypal.heapdumptool.sanitizer.HeapRecord.STRING_IN_UTF8;
 import static org.apache.commons.lang3.BooleanUtils.isFalse;
 
 /**
@@ -37,20 +46,24 @@ import static org.apache.commons.lang3.BooleanUtils.isFalse;
  */
 public class HeapDumpSanitizer {
 
-    private static final int TAG_HEAP_DUMP = 0x0C;
-    private static final int TAG_HEAP_DUMP_SEGMENT = 0x1C;
+    private static final String STRING_CODER_FIELD = "coder";
 
     private static final InternalLogger LOGGER = InternalLogger.getLogger(HeapDumpSanitizer.class);
 
     // for debugging/testing
     private static final boolean enableSanitization = isFalse(Boolean.getBoolean("disable-sanitization"));
 
+
     private InputStream inputStream;
     private OutputStream outputStream;
     private ProgressMonitor progressMonitor;
-    private String sanitizationText;
-    private boolean sanitizeArraysOnly;
-    private boolean sanitizeByteCharArraysOnly;
+    private SanitizeCommand sanitizeCommand;
+
+    private Map<Long, String> stringIdToStringMap = new HashMap<>();
+    private Map<Long, Long> classObjectIdToStringIdMap = new HashMap<>();
+    private final List<Field> stringInstanceFields = new ArrayList<>();
+    private Long stringClassObjectId;
+    private Byte sanitizationTextCoder;
 
     public void setInputStream(final InputStream inputStream) {
         this.inputStream = inputStream;
@@ -64,27 +77,11 @@ public class HeapDumpSanitizer {
         this.progressMonitor = numBytesWrittenMonitor;
     }
 
-    public void setSanitizationText(final String sanitizationText) {
-        this.sanitizationText = sanitizationText;
-    }
-
-    public void setSanitizeArraysOnly(final boolean sanitizeArraysOnly) {
-        if (sanitizeArraysOnly && sanitizeByteCharArraysOnly) {
-            throw new IllegalArgumentException("sanitizeArraysOnly and sanitizeByteCharArraysOnly cannot be both set to true simultaneously");
-        }
-        this.sanitizeArraysOnly = sanitizeArraysOnly;
-    }
-
-    public void setSanitizeByteCharArraysOnly(final boolean sanitizeByteCharArraysOnly) {
-        if (sanitizeArraysOnly && sanitizeByteCharArraysOnly) {
-            throw new IllegalArgumentException("sanitizeArraysOnly and sanitizeByteCharArraysOnly cannot be both set to true simultaneously");
-        }
-        this.sanitizeByteCharArraysOnly = sanitizeByteCharArraysOnly;
+    public void setSanitizeCommand(final SanitizeCommand sanitizeCommand) {
+        this.sanitizeCommand = sanitizeCommand;
     }
 
     public void sanitize() throws IOException {
-        Validate.notEmpty(sanitizationText);
-
         final Pipe pipe = new Pipe(inputStream, outputStream, progressMonitor);
 
         /*
@@ -116,19 +113,48 @@ public class HeapDumpSanitizer {
             if (tag == -1) {
                 break;
             }
+            final HeapRecord heapRecord = HeapRecord.findByTag(tag);
 
             pipe.pipeU4(); // timestamp
             final long length = pipe.pipeU4();
             LOGGER.debug("Tag: {}", tag);
             LOGGER.debug("Length: {}", length);
 
-            if (isHeapDumpRecord(tag)) {
+            if (heapRecord == HEAP_DUMP || heapRecord == HEAP_DUMP_SEGMENT) {
                 final Pipe heapPipe = pipe.newInputBoundedPipe(length);
                 copyHeapDumpRecord(heapPipe);
+
+            } else if (heapRecord == STRING_IN_UTF8) {
+                copyStringInUtf8Record(pipe, length);
+
+            } else if (heapRecord == LOAD_CLASS) {
+                copyLoadClassRecord(pipe);
+
             } else {
                 pipe.pipe(length);
             }
         }
+    }
+
+    private void copyLoadClassRecord(final Pipe pipe) throws IOException {
+        if (!sanitizeCommand.isForceMatchStringCoder()) {
+            return;
+        }
+        pipe.pipeU4(); // class serial number
+        final long classObjectId = pipe.pipeId();// class object ID
+        pipe.pipeU4(); // stack trace serial number
+        final long id = pipe.pipeId();// class name string ID
+        classObjectIdToStringIdMap.put(classObjectId, id);
+    }
+
+    private void copyStringInUtf8Record(final Pipe pipe, final long length) throws IOException {
+        if (!sanitizeCommand.isForceMatchStringCoder()) {
+            return;
+        }
+        final long id = pipe.pipeId();
+        final Pipe dataPipe = pipe.newInputBoundedPipe(length - pipe.getIdSize());
+        final String string = dataPipe.pipeString(length);
+        stringIdToStringMap.put(id, string);
     }
 
     private void copyHeapDumpRecord(final Pipe pipe) throws IOException {
@@ -139,7 +165,7 @@ public class HeapDumpSanitizer {
             }
             LOGGER.debug("Heap Dump Tag: {}", tag);
 
-            pipe.pipeId();
+            final long id = pipe.pipeId();
             switch (tag) {
                 case 0xFF:
                     break;
@@ -172,19 +198,19 @@ public class HeapDumpSanitizer {
                     break;
 
                 case 0x20:
-                    copyHeapDumpClassDump(pipe, tag);
+                    copyHeapDumpClassDump(pipe, id);
                     break;
 
                 case 0x21:
-                    copyHeapDumpInstanceDump(pipe, tag);
+                    copyHeapDumpInstanceDump(pipe);
                     break;
 
                 case 0x22:
-                    copyHeapDumpObjectArrayDump(pipe, tag);
+                    copyHeapDumpObjectArrayDump(pipe);
                     break;
 
                 case 0x23:
-                    copyHeapDumpPrimitiveArrayDump(pipe, tag);
+                    copyHeapDumpPrimitiveArrayDump(pipe);
                     break;
 
                 default:
@@ -193,7 +219,7 @@ public class HeapDumpSanitizer {
         }
     }
 
-    private void copyHeapDumpClassDump(final Pipe pipe, @SuppressWarnings("unused") final int id) throws IOException {
+    private void copyHeapDumpClassDump(final Pipe pipe, final long classObjectId) throws IOException {
         pipe.pipeU4(); // stacktrace
         pipe.pipeId(); // super class object id
         pipe.pipeId(); // class loader object id
@@ -217,16 +243,37 @@ public class HeapDumpSanitizer {
             pipeStaticField(pipe, entryType);
         }
 
+        final Long classStringId = classObjectIdToStringIdMap.get(classObjectId);
+        final String className = stringIdToStringMap.getOrDefault(classStringId, "");
+        final boolean isStringClass = String.class.getName().replace(".", "/").equals(className);
+        boolean stringHasCoderField = false;
+
         final int numInstanceFields = pipe.pipeU2();
         for (int i = 0; i < numInstanceFields; i++) {
-            pipe.pipeId();
-            pipe.pipeU1();
+            final long fieldNameStringId = pipe.pipeId();
+            final int fieldType = pipe.pipeU1();
+
+            if (isStringClass && sanitizeCommand.isForceMatchStringCoder()) {
+                final String fieldName = this.stringIdToStringMap.getOrDefault(fieldNameStringId, "");
+                final BasicType basicType = BasicType.findByU1Code(fieldType).orElseThrow(IllegalStateException::new);
+                stringClassObjectId = classObjectId;
+                stringInstanceFields.add(new Field(fieldName, basicType));
+                if (STRING_CODER_FIELD.equals(fieldName)) {
+                    stringHasCoderField = true;
+                }
+            }
+        }
+
+        if (isStringClass && sanitizeCommand.isForceMatchStringCoder()) {
+            stringClassObjectId = stringHasCoderField ? stringClassObjectId : null;
+            classObjectIdToStringIdMap = Collections.singletonMap(classObjectId, classStringId);
+            stringIdToStringMap = Collections.singletonMap(classStringId, className);
         }
     }
 
     private void pipeStaticField(final Pipe pipe, final int entryType) throws IOException {
         final int valueSize = BasicType.findValueSize(entryType, pipe.getIdSize());
-        if (enableSanitization && !sanitizeByteCharArraysOnly && !sanitizeArraysOnly) {
+        if (isSanitizeAll()) {
             applySanitization(pipe, valueSize);
         } else {
             pipe.pipe(valueSize);
@@ -248,18 +295,42 @@ public class HeapDumpSanitizer {
      * u4  number of bytes that follow
      * [value]*  instance field values (this class, followed by super class, etc)
      */
-    private void copyHeapDumpInstanceDump(final Pipe pipe, @SuppressWarnings("unused") final int id) throws IOException {
+    private void copyHeapDumpInstanceDump(final Pipe pipe) throws IOException {
         pipe.pipeU4();
-        pipe.pipeId();
-        final long numBytes = pipe.pipeU4();
-        if (enableSanitization && !sanitizeByteCharArraysOnly && !sanitizeArraysOnly) {
-            applySanitization(pipe, numBytes);
-        } else {
+        final long classObjectId = pipe.pipeId();
+        long numBytes = pipe.pipeU4();
+
+        if (sanitizeCommand.isForceMatchStringCoder() && Objects.equals(classObjectId, stringClassObjectId)) {
+            for (final Field field : stringInstanceFields) {
+                if (STRING_CODER_FIELD.equals(field.getFieldName())) {
+                    final int coder = isLatin1(sanitizeCommand.getSanitizationText()) ? 0 : 1;
+                    pipe.readU1();
+                    pipe.writeU1(coder);
+                    numBytes -= 1;
+                } else {
+                    final int fieldSize = field.getFieldType().getValueSize(pipe.getIdSize());
+                    pipe.pipe(fieldSize);
+                    numBytes -= fieldSize;
+                }
+            }
+
             pipe.pipe(numBytes);
+        } else {
+            if (isSanitizeAll()) {
+                applySanitization(pipe, numBytes);
+            } else {
+                pipe.pipe(numBytes);
+            }
         }
     }
 
-    private void copyHeapDumpObjectArrayDump(final Pipe pipe, @SuppressWarnings("unused") final int id) throws IOException {
+    private boolean isSanitizeAll() {
+        return enableSanitization &&
+                !sanitizeCommand.isSanitizeByteCharArraysOnly() &&
+                !sanitizeCommand.isSanitizeArraysOnly();
+    }
+
+    private void copyHeapDumpObjectArrayDump(final Pipe pipe) throws IOException {
         pipe.pipeU4();
         final long numElements = pipe.pipeU4();
         pipe.pipeId();
@@ -276,14 +347,14 @@ public class HeapDumpSanitizer {
      * 	u1	element type (See Basic Type)
      * 	[u1]*	elements (packed array)
      */
-    private void copyHeapDumpPrimitiveArrayDump(final Pipe pipe, @SuppressWarnings("unused") final int id) throws IOException {
+    private void copyHeapDumpPrimitiveArrayDump(final Pipe pipe) throws IOException {
         pipe.pipeU4();
         final long numElements = pipe.pipeU4();
 
         final int elementType = pipe.pipeU1();
         final int elementSize = BasicType.findValueSize(elementType, pipe.getIdSize());
 
-        final long numBytes = Math.multiplyExact(numElements, elementSize);
+        final long numBytes = Math.multiplyExact(numElements, (long) elementSize);
 
         if (shouldApplyArraySanitization(elementType)) {
             applySanitization(pipe, numBytes);
@@ -298,26 +369,30 @@ public class HeapDumpSanitizer {
         }
 
         final Optional<BasicType> typeOptional = BasicType.findByU1Code(elementType);
-        if (sanitizeByteCharArraysOnly) {
+        if (sanitizeCommand.isSanitizeByteCharArraysOnly()) {
             return typeOptional.filter(type -> type == BasicType.BYTE || type == BasicType.CHAR)
-                               .isPresent();
+                    .isPresent();
         }
 
         return typeOptional.filter(type -> type != BasicType.OBJECT)
-                           .isPresent();
+                .isPresent();
     }
 
     private void applySanitization(final Pipe pipe, final long numBytes) throws IOException {
         pipe.skipInput(numBytes);
 
-        final byte[] replacementData = sanitizationText.getBytes(StandardCharsets.UTF_8);
+        final byte[] replacementData = sanitizeCommand.getSanitizationText().getBytes(StandardCharsets.UTF_8);
         try (final InputStream replacementDataStream = new InfiniteCircularInputStream(replacementData)) {
             pipe.copyFrom(replacementDataStream, numBytes);
         }
     }
 
-    private boolean isHeapDumpRecord(final int tag) {
-        return tag == TAG_HEAP_DUMP || tag == TAG_HEAP_DUMP_SEGMENT;
+    private static boolean isLatin1(final String input) {
+        for (final char c : input.toCharArray()) {
+            if (c > 0xFF) {
+                return false;
+            }
+        }
+        return true;
     }
-
 }

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/HeapRecord.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/HeapRecord.java
@@ -1,0 +1,45 @@
+package com.paypal.heapdumptool.sanitizer;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum HeapRecord {
+
+    STRING_IN_UTF8(0x01),
+    LOAD_CLASS(0x02),
+    UNLOAD_CLASS(0x03),
+    STACK_FRAME(0x04),
+    STACK_TRACE(0x05),
+    ALLOC_SITES(0x06),
+    HEAP_SUMMARY(0x07),
+    START_THREAD(0x0A),
+    END_THREAD(0x0B),
+    HEAP_DUMP(0x0C),
+    HEAP_DUMP_SEGMENT(0x1C),
+    HEAP_DUMP_END(0x2C),
+    CPU_SAMPLES(0x0D),
+    CONTROL_SETTINGS(0x0E),
+    ;
+
+    private final int tag;
+
+    private static final Map<Integer, HeapRecord> tagToHeapRecord = Arrays.stream(HeapRecord.values())
+            .collect(Collectors.toMap(HeapRecord::getTag, Function.identity()));
+
+    HeapRecord(final int tag) {
+        this.tag = tag;
+    }
+
+    public int getTag() {
+        return tag;
+    }
+
+    public static HeapRecord findByTag(final int tag) {
+        final HeapRecord heapRecord = tagToHeapRecord.get(tag);
+        Objects.requireNonNull(heapRecord);
+        return heapRecord;
+    }
+}

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/Pipe.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/Pipe.java
@@ -5,11 +5,13 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.lang3.Validate;
 
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  * For piping or copying data from input to output streams.
@@ -118,5 +120,13 @@ public class Pipe {
             }
         }
         return sb.toString();
+    }
+
+    public String pipeString(final long numBytes) throws IOException {
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        IOUtils.copyLarge(input, byteArrayOutputStream, 0, numBytes);
+        final byte[] bytes = byteArrayOutputStream.toByteArray();
+        IOUtils.write(bytes, output);
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeCommand.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeCommand.java
@@ -38,6 +38,14 @@ public class SanitizeCommand implements CliCommand {
     @Option(names = {"-t", "--text"}, description = "Sanitization text to replace with", defaultValue = "\\0", showDefaultValue = ALWAYS)
     private String sanitizationText = "\\0";
 
+    @Option(names = {"-f", "--force-string-coder-match"},
+            description = "Force strings coder values to match sanitizationText.coder value",
+            defaultValue = "true", showDefaultValue = ALWAYS)
+    // Suppose sanitizationText=*. If the coder value is not forced to match, the heap dump analyze tools like Eclipse
+    // MAT might display escaped "\\u2A" (where 2A is ascii value) for Strings with coder==1. By forcing the coder value to
+    // match, all strings would be displayed as "*"
+    private boolean forceMatchStringCoder;
+
     @Option(names = {"-s", "--sanitize-byte-char-arrays-only"}, description = "Sanitize byte/char arrays only", defaultValue = "true", showDefaultValue = ALWAYS)
     private boolean sanitizeByteCharArraysOnly = true;
 
@@ -107,6 +115,14 @@ public class SanitizeCommand implements CliCommand {
     public void setSanitizationText(final String sanitizationText) {
         // e.g. unescape user-supplied \\0 string (2 chars) to \0 string (1 char)
         this.sanitizationText = StringEscapeUtils.unescapeJava(sanitizationText);
+    }
+
+    public boolean isForceMatchStringCoder() {
+        return forceMatchStringCoder;
+    }
+
+    public void setForceMatchStringCoder(final boolean forceMatchStringCoder) {
+        this.forceMatchStringCoder = forceMatchStringCoder;
     }
 
     public boolean isZipOutput() {

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeCommandProcessor.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeCommandProcessor.java
@@ -37,6 +37,11 @@ public class SanitizeCommandProcessor implements CliCommandProcessor {
 
     @Override
     public void process() throws Exception {
+        if (command.isSanitizeArraysOnly() && command.isSanitizeByteCharArraysOnly()) {
+            throw new IllegalArgumentException("sanitizeArraysOnly and sanitizeByteCharArraysOnly cannot be both set to true simultaneously");
+        }
+        Validate.notEmpty(command.getSanitizationText());
+
         LOGGER.info("Starting heap dump sanitization");
         LOGGER.info("Input File: {}", command.getInputFile());
         LOGGER.info("Output File: {}", command.getOutputFile());
@@ -49,9 +54,7 @@ public class SanitizeCommandProcessor implements CliCommandProcessor {
             sanitizer.setInputStream(inputStream);
             sanitizer.setOutputStream(outputStream);
             sanitizer.setProgressMonitor(numBytesProcessedMonitor(command.getBufferSize(), LOGGER));
-            sanitizer.setSanitizationText(command.getSanitizationText());
-            sanitizer.setSanitizeByteCharArraysOnly(command.isSanitizeByteCharArraysOnly());
-            sanitizer.setSanitizeArraysOnly(command.isSanitizeArraysOnly());
+            sanitizer.setSanitizeCommand(command);
 
             sanitizer.sanitize();
         }


### PR DESCRIPTION
Suppose sanitizationText=*. Eclipse Memory Analyzer (and similar tools) may display sanitizationText in escaped "\u2A" form if the original string has UTF16 encoding.

In such cases, force string instance's coder value to ASCII Latin1 so that sanitizationText is displayed.

fixes issue #28