### PR TITLE
add ability to exclude certain string fields from sanitization.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ test-output
 /.apt_generated_tests/
 
 *.jar
+*.zip

--- a/README.md
+++ b/README.md
@@ -140,27 +140,33 @@ Additional usage for sub-commands can be found by running `help {sub-command}`. 
 
 ```
 $ java -jar heap-dump-tool.jar help capture
-Usage: heap-dump-tool capture [OPTIONS] <containerName>
-Capture sanitized heap dump of a containerized app
-Plain thread dump is also captured
-      <containerName>   Container name
+Usage: heap-dump-tool sanitize [OPTIONS] <inputFile> <outputFile>
+Sanitize a heap dump by replacing byte and char array contents
+      <inputFile>    Input heap dump .hprof. File or stdin
+      <outputFile>   Output heap dump .hprof. File, stdout, or stderr
+  -a, --tar-input    Treat input as tar archive
   -b, --buffer-size=<bufferSize>
-                        Buffer size for reading and writing
-                          Default: 100MB
+                     Buffer size for reading and writing
+                       Default: 100MB
   -d, --docker-registry=<dockerRegistry>
-                        docker registry hostname for bootstrapping heap-dump-tool docker image
-  -f, --force-string-coder-match
+                     docker registry hostname for bootstrapping heap-dump-tool docker image
+  -e, --exclude-string-fields=<excludeStringFields>
+                     String fields to exclude from sanitization. Value in com.example.MyClass#fieldName format
+                       Default: java.lang.Thread#name,java.lang.ThreadGroup#name
+  -f, --force-string-coder-match=<forceMatchStringCoder>
                      Force strings coder values to match sanitizationText.coder value
                        Default: true
-  -p, --pid=<pid>       Pid within the container, if there are multiple Java processes
   -s, --sanitize-byte-char-arrays-only
-                        Sanitize byte/char arrays only
-                          Default: true
+                     Sanitize byte/char arrays only
+                       Default: true
+  -S, --sanitize-arrays-only
+                     Sanitize arrays only
+                       Default: false
   -t, --text=<sanitizationText>
-                        Sanitization text to replace with
-                          Default: \0
-  -z, --zip-output      Write zipped output
-                          Default: true
+                     Sanitization text to replace with
+                       Default: \0
+  -z, --zip-output   Write zipped output
+                       Default: false
 ```
 
 <a name="license"></a>

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,13 @@
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/paypal/heapdumptool/capture/CaptureCommand.java
+++ b/src/main/java/com/paypal/heapdumptool/capture/CaptureCommand.java
@@ -1,17 +1,16 @@
 package com.paypal.heapdumptool.capture;
 
 import com.paypal.heapdumptool.cli.CliCommand;
-import com.paypal.heapdumptool.sanitizer.DataSize;
-import org.apache.commons.text.StringEscapeUtils;
+import com.paypal.heapdumptool.sanitizer.SanitizeOrCaptureCommandBase;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
-import static com.paypal.heapdumptool.sanitizer.DataSize.ofMegabytes;
 import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
 import static org.apache.commons.lang3.builder.ToStringStyle.MULTI_LINE_STYLE;
 import static picocli.CommandLine.Help.Visibility.ALWAYS;
@@ -22,10 +21,10 @@ import static picocli.CommandLine.Help.Visibility.ALWAYS;
                 "Plain thread dump is also captured"
         },
         abbreviateSynopsis = true)
-public class CaptureCommand implements CliCommand {
+public class CaptureCommand extends SanitizeOrCaptureCommandBase implements CliCommand {
 
     static final String DOCKER_REGISTRY_OPTION = "--docker-registry";
-    
+
     // to allow field injection from picocli, these variables can't be final
 
     @Parameters(index = "0", description = "Container name")
@@ -34,21 +33,9 @@ public class CaptureCommand implements CliCommand {
     @Option(names = { "-p", "--pid" }, description = "Pid within the container, if there are multiple Java processes")
     private Long pid;
 
-    @Option(names = { "-z", "--zip-output" }, description = "Write zipped output", defaultValue = "true", showDefaultValue = ALWAYS)
-    private boolean zipOutput = true;
-
-    @Option(names = { "-t", "--text" }, description = "Sanitization text to replace with", defaultValue = "\\0", showDefaultValue = ALWAYS)
-    private String sanitizationText = "\\0";
-
-    @Option(names = { "-s", "--sanitize-byte-char-arrays-only" }, description = "Sanitize byte/char arrays only", defaultValue = "true", showDefaultValue = ALWAYS)
-    private boolean sanitizeByteCharArraysOnly = true;
-
-    @Option(names = { "-b", "--buffer-size" }, description = "Buffer size for reading and writing", defaultValue = "100MB", showDefaultValue = ALWAYS)
-    private DataSize bufferSize = ofMegabytes(100);
-
     @Option(names = { "--heap-cmd" }, description = "Command to capture heap dump", defaultValue = "jcmd PID GC.heap_dump FILE_PATH", showDefaultValue = ALWAYS)
     // e.g. set --heap-cmd "jcmd PID GC.heap_dump -all FILE_PATH" to pass -all flag to jcmd heap dump
-    private List<String> heapCmd = new ArrayList<>(Arrays.asList("jcmd PID GC.heap_dump FILE_PATH"));
+    private List<String> heapCmd = new ArrayList<>(Collections.singletonList("jcmd PID GC.heap_dump FILE_PATH"));
 
     @Option(names = { "--heap-options" }, description = "Options to heap dump command", defaultValue = "", showDefaultValue = ALWAYS)
     // e.g. set --heap-options -all to pass -all flag to jcmd heap dump
@@ -56,7 +43,7 @@ public class CaptureCommand implements CliCommand {
 
     @Option(names = { "--thread-cmd" }, description = "Command to capture thread dump", defaultValue = "jcmd PID Thread.print -l", showDefaultValue = ALWAYS)
     // e.g. set --thread-cmd "jcmd 1 Thread.dump_to_file -format=json -" to thread dump in json format
-    private List<String> threadCmd = new ArrayList<>(Arrays.asList("jcmd PID Thread.print -l"));
+    private List<String> threadCmd = new ArrayList<>(Collections.singletonList("jcmd PID Thread.print -l"));
 
     @Option(names = { "--thread-option" }, description = "Options to thread dump command", defaultValue = "", showDefaultValue = ALWAYS)
     private List<String> threadOptions = new ArrayList<>();
@@ -64,14 +51,6 @@ public class CaptureCommand implements CliCommand {
     @Override
     public Class<CaptureCommandProcessor> getProcessorClass() {
         return CaptureCommandProcessor.class;
-    }
-
-    public DataSize getBufferSize() {
-        return bufferSize;
-    }
-
-    public void setBufferSize(final DataSize bufferSize) {
-        this.bufferSize = bufferSize;
     }
 
     public String getContainerName() {
@@ -88,31 +67,6 @@ public class CaptureCommand implements CliCommand {
 
     public void setPid(final Long pid) {
         this.pid = pid;
-    }
-
-    public boolean isZipOutput() {
-        return zipOutput;
-    }
-
-    public void setZipOutput(final boolean zipOutput) {
-        this.zipOutput = zipOutput;
-    }
-
-    public boolean isSanitizeByteCharArraysOnly() {
-        return sanitizeByteCharArraysOnly;
-    }
-
-    public void setSanitizeByteCharArraysOnly(final boolean sanitizeByteCharArraysOnly) {
-        this.sanitizeByteCharArraysOnly = sanitizeByteCharArraysOnly;
-    }
-
-    public String getSanitizationText() {
-        return StringEscapeUtils.unescapeJava(sanitizationText);
-    }
-
-    public void setSanitizationText(final String sanitizationText) {
-        // e.g. unescape user-supplied \\0 string (2 chars) to \0 string (1 char)
-        this.sanitizationText = StringEscapeUtils.unescapeJava(sanitizationText);
     }
 
     public List<String> getHeapCmd() {

--- a/src/main/java/com/paypal/heapdumptool/capture/CaptureCommandProcessor.java
+++ b/src/main/java/com/paypal/heapdumptool/capture/CaptureCommandProcessor.java
@@ -6,6 +6,7 @@ import com.paypal.heapdumptool.sanitizer.SanitizeCommandProcessor;
 import com.paypal.heapdumptool.utils.InternalLogger;
 import com.paypal.heapdumptool.utils.ProcessTool;
 import com.paypal.heapdumptool.utils.ProcessTool.ProcessResult;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -14,9 +15,7 @@ import org.apache.commons.lang3.function.Failable;
 import org.apache.commons.text.StringSubstitutor;
 
 import java.io.Closeable;
-import java.io.FilterInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -64,13 +63,18 @@ public class CaptureCommandProcessor implements CliCommandProcessor {
 
         final long pid = findPidInAppContainer();
 
-        final Path inputHeapDumpFile = createPlainHeapDumpInAppContainer(pid);
+        final Path heapDumpFileInContainer = createPlainHeapDumpInAppContainer(pid);
         final String threadDump = captureThreadDump(pid);
+        final Path heapDumpFileOnHost = FileUtils.getTempDirectory()
+                .toPath()
+                .resolve(heapDumpFileInContainer.getFileName().toString());
         final Path output;
-        try (final InputStream inputStream = createCopyStreamOutOfAppContainer(inputHeapDumpFile)) {
-            output = sanitizeHeapDump(inputHeapDumpFile, inputStream, threadDump);
+        try {
+            copyFileOutOfAppContainer(heapDumpFileInContainer, heapDumpFileOnHost);
+            output = sanitizeHeapDump(heapDumpFileOnHost, threadDump);
         } finally {
-            deletePlainHeapDumpInAppContainer(inputHeapDumpFile);
+            deletePlainHeapDumpInAppContainer(heapDumpFileOnHost);
+            Files.deleteIfExists(heapDumpFileOnHost);
         }
 
         LOGGER.info("Captured sanitized heap dump in {}. Output: {}", getFriendlyDuration(now), output);
@@ -79,7 +83,7 @@ public class CaptureCommandProcessor implements CliCommandProcessor {
     private String captureThreadDump(final long pid) throws Exception {
         // jcmd PID Thread.print
         final List<Object> cmd = new ArrayList<>(command.getThreadCmd());
-        cmd.addAll(3, command.getThreadOptions());
+        addIfNotEmpty(command.getThreadOptions(), cmd);
         final Object[] cmdArray = cmd.stream()
                 .map(arg -> "PID".equals(arg) ? pid : arg)
                 .toArray();
@@ -87,24 +91,22 @@ public class CaptureCommandProcessor implements CliCommandProcessor {
         return result.stdout;
     }
 
-    private Path sanitizeHeapDump(final Path filePath, final InputStream inputStream, final String threadDump) throws Exception {
-        final String destFile = filePath.getFileName().toAbsolutePath() // re-eval filename in current cwd
+    private Path sanitizeHeapDump(final Path inputFile, final String threadDump) throws Exception {
+        final String destFile = inputFile.getFileName().toAbsolutePath() // re-eval filename in current cwd
                 + ".zip";
         final Path destFilePath = Paths.get(destFile);
 
         final SanitizeCommand sanitizeCommand = new SanitizeCommand();
-        sanitizeCommand.setInputFile(filePath); // not used. for display only
+        sanitizeCommand.copyFrom(this.command);
+        sanitizeCommand.setInputFile(inputFile);
         sanitizeCommand.setOutputFile(destFilePath);
-        sanitizeCommand.setBufferSize(command.getBufferSize());
-        sanitizeCommand.setTarInput(true);
         sanitizeCommand.setZipOutput(true);
 
-        try (final CaptureStreamFactory captureStreamFactory = new CaptureStreamFactory(sanitizeCommand, inputStream)) {
-
+        try (final CaptureStreamFactory captureStreamFactory = new CaptureStreamFactory(sanitizeCommand)) {
             final SanitizeCommandProcessor processor = SanitizeCommandProcessor.newInstance(sanitizeCommand, captureStreamFactory);
             processor.process();
 
-            writeThreadDump(threadDump, filePath, captureStreamFactory);
+            writeThreadDump(threadDump, inputFile, captureStreamFactory);
         }
 
         updateFilePermissions(destFilePath);
@@ -115,8 +117,8 @@ public class CaptureCommandProcessor implements CliCommandProcessor {
         final ZipOutputStream zipStream = (ZipOutputStream) captureStreamFactory.getNativeOutputStream();
 
         final String fileName = filePath.getFileName()
-                                        .toString()
-                                        .replace(".hprof", ".threads.txt");
+                .toString()
+                .replace(".hprof", ".threads.txt");
         Validate.validState(fileName.endsWith(".threads.txt"));
 
         zipStream.putNextEntry(new ZipEntry(fileName));
@@ -134,28 +136,23 @@ public class CaptureCommandProcessor implements CliCommandProcessor {
 
     private Set<PosixFilePermission> globalReadWritePermissions() {
         return Stream.of(PosixFilePermission.values())
-                     .filter(permission -> !permission.name().contains("EXECUTE"))
-                     .collect(Collectors.toSet());
+                .filter(permission -> !permission.name().contains("EXECUTE"))
+                .collect(Collectors.toSet());
     }
 
-    private InputStream createCopyStreamOutOfAppContainer(final Path filePath) throws IOException {
-        final String src = command.getContainerName() + ":" + filePath;
-        final String[] args = array(DOCKER, "cp", src, "-");
+    private void copyFileOutOfAppContainer(
+            final Path heapDumpFileInContainer,
+            final Path heapDumpFileOnHost) throws IOException, InterruptedException {
+        final String src = command.getContainerName() + ":" + heapDumpFileInContainer;
+        final String[] args = array(DOCKER, "cp", src, heapDumpFileOnHost.toString());
         logProcessArgs(args);
 
         final String[] cmd = nsenterIfNeeded(args);
         final Process process = processBuilder(cmd).start();
         closeQuietly(process.getOutputStream());
         closeQuietly(process.getErrorStream());
-
-        return new FilterInputStream(process.getInputStream()) {
-
-            @Override
-            public void close() throws IOException {
-                super.close();
-                process.destroy();
-            }
-        };
+        final int exitCode = process.waitFor();
+        Validate.isTrue(exitCode == 0, "exitCode=" + exitCode);
     }
 
     private void deletePlainHeapDumpInAppContainer(final Path filePath) throws Exception {
@@ -169,16 +166,17 @@ public class CaptureCommandProcessor implements CliCommandProcessor {
 
         final ProcessResult result = Failable.call(() -> execInAppContainer("jps"));
         final Stream<String> javaProcesses = result.stdoutLines()
-                                                   .stream()
-                                                   .map(String::trim)
-                                                   .filter(StringUtils::isNotEmpty)
-                                                   .filter(line -> !substringAfterLast(line, " ").equals("Jps"));
+                .stream()
+                .map(String::trim)
+                .filter(StringUtils::isNotEmpty)
+                .filter(line -> !substringAfterLast(line, " ").equals("Jps"));
 
         final long[] pids = javaProcesses.map(line -> substringBefore(line, " "))
-                                         .mapToLong(Long::parseLong)
-                                         .toArray();
+                .mapToLong(Long::parseLong)
+                .toArray();
 
-        Validate.validState(pids.length == 1, "Cannot find unique Java process. container=%s found=%s", command.getContainerName(), Arrays.toString(pids));
+        Validate.validState(pids.length == 1, "Cannot find unique Java process. Passing in --pid=PID." +
+                " container=%s found=%s", command.getContainerName(), Arrays.toString(pids));
         return pids[0];
     }
 
@@ -187,22 +185,28 @@ public class CaptureCommandProcessor implements CliCommandProcessor {
 
         // jcmd PID GC.heap_dump FILE_PATH
         final List<Object> cmd = new ArrayList<>(command.getHeapCmd());
-        cmd.addAll(3, command.getHeapOptions());
+        addIfNotEmpty(command.getHeapOptions(), cmd);
         final Object[] cmdArray = cmd.stream()
                 .map(arg -> "PID".equals(arg) ? pid : arg)
                 .map(arg -> "FILE_PATH".equals(arg) ? filePath : arg)
                 .toArray();
         final ProcessResult result = execInAppContainer(cmdArray);
         Validate.validState(result.stdout.contains("Heap dump file created"),
-                            "Cannot create heap dump. container=%s pid=%s"
-                                    + "\nstdout=%s"
-                                    + "\nstderr=%s",
-                            command.getContainerName(),
-                            pid,
-                            result.stdout,
-                            result.stderr);
+                "Cannot create heap dump. container=%s pid=%s"
+                        + "\nstdout=%s"
+                        + "\nstderr=%s",
+                command.getContainerName(),
+                pid,
+                result.stdout,
+                result.stderr);
 
         return filePath;
+    }
+
+    private static void addIfNotEmpty(final List<String> src, final List<Object> dest) {
+        src.stream()
+                .filter(StringUtils::isNotEmpty)
+                .forEach(dest::add);
     }
 
     private Path newHeapDumpFilePath() {
@@ -217,25 +221,25 @@ public class CaptureCommandProcessor implements CliCommandProcessor {
     private void validateContainerRunning() throws Exception {
         final ProcessResult result = invokePrivilegedProcess(DOCKER, "ps", "--filter", "name=" + command.getContainerName());
         result.stdoutLines()
-              .stream()
-              .skip(1)
-              .map(String::trim)
-              .filter(StringUtils::isNotEmpty)
-              .filter(line -> {
-                  final String actualContainerName = substringAfterLast(line, " ");
-                  return actualContainerName.equals(command.getContainerName());
-              })
-              .findFirst()
-              .orElseThrow(() -> new IllegalArgumentException("Cannot find container. name=" + command.getContainerName()));
+                .stream()
+                .skip(1)
+                .map(String::trim)
+                .filter(StringUtils::isNotEmpty)
+                .filter(line -> {
+                    final String actualContainerName = substringAfterLast(line, " ");
+                    return actualContainerName.equals(command.getContainerName());
+                })
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Cannot find container. name=" + command.getContainerName()));
     }
 
     private ProcessResult execInAppContainer(final Object... args) throws Exception {
         final String[] stringArgs = Stream.of(args)
-                                          .map(String::valueOf)
-                                          .toArray(String[]::new);
+                .map(String::valueOf)
+                .toArray(String[]::new);
 
         final String[] cmd = concat(array(DOCKER, "exec", command.getContainerName()),
-                                    stringArgs);
+                stringArgs);
         return invokePrivilegedProcess(cmd);
     }
 

--- a/src/main/java/com/paypal/heapdumptool/capture/CaptureStreamFactory.java
+++ b/src/main/java/com/paypal/heapdumptool/capture/CaptureStreamFactory.java
@@ -6,28 +6,18 @@ import org.apache.commons.io.output.CloseShieldOutputStream;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static java.util.Objects.requireNonNull;
 import static org.apache.commons.io.IOUtils.closeQuietly;
 
 public class CaptureStreamFactory extends SanitizeStreamFactory implements Closeable {
 
-    private final AtomicReference<InputStream> inputStreamRef;
     private final AtomicReference<OutputStream> outputStreamRef;
 
-    public CaptureStreamFactory(final SanitizeCommand command, final InputStream inputStream) {
+    public CaptureStreamFactory(final SanitizeCommand command) {
         super(command);
-        this.inputStreamRef = new AtomicReference<>(inputStream);
         this.outputStreamRef = new AtomicReference<>();
-    }
-
-    @Override
-    protected InputStream newInputStream(final Path ignored) {
-        return requireNonNull(inputStreamRef.getAndSet(null));
     }
 
     @Override

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/ClassObject.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/ClassObject.java
@@ -1,0 +1,24 @@
+package com.paypal.heapdumptool.sanitizer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
+import static org.apache.commons.lang3.builder.ToStringStyle.MULTI_LINE_STYLE;
+
+public class ClassObject {
+
+    public final long id;
+    public final long superClassObjectId;
+    public final List<Field> fields = new ArrayList<>();
+
+    public ClassObject(final long id, final long superClassObjectId) {
+        this.id = id;
+        this.superClassObjectId = superClassObjectId;
+    }
+
+    @Override
+    public String toString() {
+        return reflectionToString(this, MULTI_LINE_STYLE);
+    }
+}

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/Field.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/Field.java
@@ -1,28 +1,20 @@
 package com.paypal.heapdumptool.sanitizer;
 
+import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
+import static org.apache.commons.lang3.builder.ToStringStyle.MULTI_LINE_STYLE;
+
 public class Field {
 
-    private final String fieldName;
-    private final BasicType fieldType;
+    public final String name;
+    public final BasicType type;
 
-    public Field(final String fieldName, final BasicType fieldType) {
-        this.fieldName = fieldName;
-        this.fieldType = fieldType;
-    }
-
-    public String getFieldName() {
-        return fieldName;
-    }
-
-    public BasicType getFieldType() {
-        return fieldType;
+    public Field(final String name, final BasicType type) {
+        this.name = name;
+        this.type = type;
     }
 
     @Override
     public String toString() {
-        return "Field{" +
-                "fieldName='" + fieldName + '\'' +
-                ", fieldType=" + fieldType +
-                '}';
+        return reflectionToString(this, MULTI_LINE_STYLE);
     }
 }

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/Pipe.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/Pipe.java
@@ -56,8 +56,18 @@ public class Pipe {
         return input.read();
     }
 
+    public byte[] read(final long numBytes) throws IOException {
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        IOUtils.copyLarge(input, byteArrayOutputStream, 0, numBytes);
+        return byteArrayOutputStream.toByteArray();
+    }
+
     public void writeU1(final int u1) throws IOException {
         output.write(u1);
+    }
+
+    public void write(final byte[] bytes) throws IOException {
+        IOUtils.write(bytes, output);
     }
 
     public void copyFrom(final InputStream inputStream, final long count) throws IOException {
@@ -123,10 +133,8 @@ public class Pipe {
     }
 
     public String pipeString(final long numBytes) throws IOException {
-        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        IOUtils.copyLarge(input, byteArrayOutputStream, 0, numBytes);
-        final byte[] bytes = byteArrayOutputStream.toByteArray();
-        IOUtils.write(bytes, output);
+        final byte[] bytes = read(numBytes);
+        write(bytes);
         return new String(bytes, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeCommand.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeCommand.java
@@ -1,33 +1,23 @@
 package com.paypal.heapdumptool.sanitizer;
 
 import com.paypal.heapdumptool.cli.CliCommand;
-import org.apache.commons.text.StringEscapeUtils;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 import java.nio.file.Path;
 
-import static com.paypal.heapdumptool.sanitizer.DataSize.ofMegabytes;
 import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
 import static org.apache.commons.lang3.builder.ToStringStyle.MULTI_LINE_STYLE;
 import static picocli.CommandLine.Help.Visibility.ALWAYS;
 
 @Command(name = "sanitize", description = "Sanitize a heap dump by replacing byte and char array contents", abbreviateSynopsis = true)
-public class SanitizeCommand implements CliCommand {
+public class SanitizeCommand extends SanitizeOrCaptureCommandBase implements CliCommand {
 
-    static final String DOCKER_REGISTRY_OPTION = "--docker-registry";
-    
     // to allow field injection from picocli, these variables can't be final
 
-    @Option(names = { "-d", DOCKER_REGISTRY_OPTION }, description = "docker registry hostname for bootstrapping heap-dump-tool docker image")
-    private String dockerRegistry;
-    
     @Parameters(index = "0", description = "Input heap dump .hprof. File or stdin")
     private Path inputFile;
-
-    @Option(names = {"-a", "--tar-input"}, description = "Treat input as tar archive")
-    private boolean tarInput;
 
     @Parameters(index = "1", description = "Output heap dump .hprof. File, stdout, or stderr")
     private Path outputFile;
@@ -35,53 +25,9 @@ public class SanitizeCommand implements CliCommand {
     @Option(names = {"-z", "--zip-output"}, description = "Write zipped output", showDefaultValue = ALWAYS)
     private boolean zipOutput;
 
-    @Option(names = {"-t", "--text"}, description = "Sanitization text to replace with", defaultValue = "\\0", showDefaultValue = ALWAYS)
-    private String sanitizationText = "\\0";
-
-    @Option(names = {"-f", "--force-string-coder-match"},
-            description = "Force strings coder values to match sanitizationText.coder value",
-            defaultValue = "true", showDefaultValue = ALWAYS)
-    // Suppose sanitizationText=*. If the coder value is not forced to match, the heap dump analyze tools like Eclipse
-    // MAT might display escaped "\\u2A" (where 2A is ascii value) for Strings with coder==1. By forcing the coder value to
-    // match, all strings would be displayed as "*"
-    private boolean forceMatchStringCoder;
-
-    @Option(names = {"-s", "--sanitize-byte-char-arrays-only"}, description = "Sanitize byte/char arrays only", defaultValue = "true", showDefaultValue = ALWAYS)
-    private boolean sanitizeByteCharArraysOnly = true;
-
-    @Option(names = {"--sanitize-arrays-only"}, description = "Sanitize arrays only", defaultValue = "false", showDefaultValue = ALWAYS)
-    private boolean sanitizeArraysOnly;
-
-    @Option(names = {"-b", "--buffer-size"}, description = "Buffer size for reading and writing", defaultValue = "100MB", showDefaultValue = ALWAYS)
-    private DataSize bufferSize = ofMegabytes(100);
-
     @Override
     public Class<SanitizeCommandProcessor> getProcessorClass() {
         return SanitizeCommandProcessor.class;
-    }
-
-    public DataSize getBufferSize() {
-        return bufferSize;
-    }
-
-    public void setBufferSize(final DataSize bufferSize) {
-        this.bufferSize = bufferSize;
-    }
-
-    public boolean isSanitizeByteCharArraysOnly() {
-        return sanitizeByteCharArraysOnly;
-    }
-
-    public void setSanitizeByteCharArraysOnly(final boolean sanitizeByteCharArraysOnly) {
-        this.sanitizeByteCharArraysOnly = sanitizeByteCharArraysOnly;
-    }
-
-    public boolean isSanitizeArraysOnly() {
-        return sanitizeArraysOnly;
-    }
-
-    public void setSanitizeArraysOnly(final boolean sanitizeArraysOnly) {
-        this.sanitizeArraysOnly = sanitizeArraysOnly;
     }
 
     public Path getInputFile() {
@@ -92,37 +38,12 @@ public class SanitizeCommand implements CliCommand {
         this.inputFile = inputFile;
     }
 
-    public boolean isTarInput() {
-        return tarInput;
-    }
-
-    public void setTarInput(final boolean tarInput) {
-        this.tarInput = tarInput;
-    }
-
     public Path getOutputFile() {
         return outputFile;
     }
 
     public void setOutputFile(final Path outputFile) {
         this.outputFile = outputFile;
-    }
-
-    public String getSanitizationText() {
-        return StringEscapeUtils.unescapeJava(sanitizationText);
-    }
-
-    public void setSanitizationText(final String sanitizationText) {
-        // e.g. unescape user-supplied \\0 string (2 chars) to \0 string (1 char)
-        this.sanitizationText = StringEscapeUtils.unescapeJava(sanitizationText);
-    }
-
-    public boolean isForceMatchStringCoder() {
-        return forceMatchStringCoder;
-    }
-
-    public void setForceMatchStringCoder(final boolean forceMatchStringCoder) {
-        this.forceMatchStringCoder = forceMatchStringCoder;
     }
 
     public boolean isZipOutput() {
@@ -137,5 +58,4 @@ public class SanitizeCommand implements CliCommand {
     public String toString() {
         return reflectionToString(this, MULTI_LINE_STYLE);
     }
-
 }

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeCommandProcessor.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeCommandProcessor.java
@@ -2,8 +2,10 @@ package com.paypal.heapdumptool.sanitizer;
 
 import com.paypal.heapdumptool.cli.CliCommandProcessor;
 import com.paypal.heapdumptool.utils.InternalLogger;
+import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang3.Validate;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.time.Instant;
@@ -40,25 +42,54 @@ public class SanitizeCommandProcessor implements CliCommandProcessor {
         if (command.isSanitizeArraysOnly() && command.isSanitizeByteCharArraysOnly()) {
             throw new IllegalArgumentException("sanitizeArraysOnly and sanitizeByteCharArraysOnly cannot be both set to true simultaneously");
         }
+        if (streamFactory.isStdinInput() && !command.getExcludeStringFields().isEmpty()) {
+            throw new IllegalArgumentException("stdin input and excludeStringFields cannot be both set to true simultaneously");
+        }
         Validate.notEmpty(command.getSanitizationText());
 
-        LOGGER.info("Starting heap dump sanitization");
+        final Instant now = Instant.now();
+
+        final HeapDumpSanitizer sanitizer = applyPreprocessing();
+        LOGGER.info("Starting heap dump sanitization ...");
         LOGGER.info("Input File: {}", command.getInputFile());
         LOGGER.info("Output File: {}", command.getOutputFile());
 
-        final Instant now = Instant.now();
         try (final InputStream inputStream = streamFactory.newInputStream();
              final OutputStream outputStream = streamFactory.newOutputStream()) {
 
-            final HeapDumpSanitizer sanitizer = new HeapDumpSanitizer();
-            sanitizer.setInputStream(inputStream);
-            sanitizer.setOutputStream(outputStream);
-            sanitizer.setProgressMonitor(numBytesProcessedMonitor(command.getBufferSize(), LOGGER));
-            sanitizer.setSanitizeCommand(command);
-
-            sanitizer.sanitize();
+            sanitize(sanitizer, inputStream, outputStream);
         }
         LOGGER.info("Finished heap dump sanitization in {}", getFriendlyDuration(now));
+    }
+
+    private HeapDumpSanitizer applyPreprocessing() throws IOException {
+        final HeapDumpSanitizer sanitizerPrototype = new HeapDumpSanitizer();
+        if (command.getExcludeStringFields().isEmpty() && !command.isForceMatchStringCoder()) {
+            return sanitizerPrototype;
+        }
+
+        LOGGER.info("Pre-processing ...");
+        LOGGER.info("    String fields to exclude from sanitization: {}", String.join(",", command.getExcludeStringFields()));
+        LOGGER.info("    Force match String.coder: {}", command.isForceMatchStringCoder());
+        LOGGER.info("Input File: {}", command.getInputFile());
+
+        try (final InputStream inputStream = streamFactory.newInputStream();
+             final OutputStream outputStream = NullOutputStream.INSTANCE) {
+
+            sanitize(sanitizerPrototype, inputStream, outputStream);
+        }
+        return sanitizerPrototype;
+    }
+
+    private void sanitize(final HeapDumpSanitizer sanitizer,
+                          final InputStream inputStream,
+                          final OutputStream outputStream) throws IOException {
+        sanitizer.setInputStream(inputStream);
+        sanitizer.setOutputStream(outputStream);
+        sanitizer.setProgressMonitor(numBytesProcessedMonitor(command.getBufferSize(), LOGGER));
+        sanitizer.setSanitizeCommand(command);
+
+        sanitizer.sanitize();
     }
 
 }

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeOrCaptureCommandBase.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeOrCaptureCommandBase.java
@@ -1,0 +1,176 @@
+package com.paypal.heapdumptool.sanitizer;
+
+import com.paypal.heapdumptool.cli.CliCommand;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
+import picocli.CommandLine.Option;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.paypal.heapdumptool.sanitizer.DataSize.ofMegabytes;
+import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
+import static org.apache.commons.lang3.builder.ToStringStyle.MULTI_LINE_STYLE;
+import static picocli.CommandLine.Help.Visibility.ALWAYS;
+
+public abstract class SanitizeOrCaptureCommandBase implements CliCommand {
+
+    static final String DOCKER_REGISTRY_OPTION = "--docker-registry";
+
+    // to allow field injection from picocli, these variables can't be final
+
+    @Option(names = {"-d", DOCKER_REGISTRY_OPTION}, description = "docker registry hostname for bootstrapping heap-dump-tool docker image")
+    private String dockerRegistry;
+
+    @Option(names = {"-a", "--tar-input"}, description = "Treat input as tar archive")
+    private boolean tarInput;
+
+    @Option(names = {"-e", "--exclude-string-fields"},
+            description = "String fields to exclude from sanitization. Value in com.example.MyClass#fieldName format",
+            defaultValue = "java.lang.Thread#name,java.lang.ThreadGroup#name",
+            showDefaultValue = ALWAYS)
+    private List<String> excludeStringFields;
+
+    @Option(names = {"-f", "--force-string-coder-match"},
+            description = "Force strings coder values to match sanitizationText.coder value",
+            defaultValue = "true",
+            arity = "1",
+            showDefaultValue = ALWAYS)
+    // Suppose sanitizationText=*. If the coder value is not forced to match, the heap dump analyze tools like Eclipse
+    // MAT might display escaped "\\u2A" (where 2A is ascii value) for Strings with coder==1. By forcing the coder value to
+    // match, all strings would be displayed as "*"
+    private boolean forceMatchStringCoder;
+
+    @Option(names = {"-s", "--sanitize-byte-char-arrays-only"}, description = "Sanitize byte/char arrays only", defaultValue = "true", showDefaultValue = ALWAYS)
+    private boolean sanitizeByteCharArraysOnly = true;
+
+    @Option(names = {"-S", "--sanitize-arrays-only"}, description = "Sanitize arrays only", defaultValue = "false", showDefaultValue = ALWAYS)
+    private boolean sanitizeArraysOnly;
+
+    @Option(names = {"-t", "--text"}, description = "Sanitization text to replace with", defaultValue = "\\0", showDefaultValue = ALWAYS)
+    private String sanitizationText = "\\0";
+
+    private StringFieldMap excludeStringFieldMap;
+
+    @Option(names = {"-b", "--buffer-size"}, description = "Buffer size for reading and writing", defaultValue = "100MB", showDefaultValue = ALWAYS)
+    private DataSize bufferSize = ofMegabytes(100);
+
+    public void copyFrom(final SanitizeOrCaptureCommandBase other) {
+        this.dockerRegistry = other.dockerRegistry;
+        this.bufferSize = other.bufferSize;
+        this.forceMatchStringCoder = other.forceMatchStringCoder;
+        this.excludeStringFields = other.excludeStringFields;
+        this.sanitizationText = other.sanitizationText;
+        this.sanitizeArraysOnly = other.sanitizeArraysOnly;
+        this.sanitizeByteCharArraysOnly = other.sanitizeByteCharArraysOnly;
+        this.tarInput = other.tarInput;
+    }
+
+    public DataSize getBufferSize() {
+        return bufferSize;
+    }
+
+    public void setBufferSize(final DataSize bufferSize) {
+        this.bufferSize = bufferSize;
+    }
+
+    public boolean isSanitizeByteCharArraysOnly() {
+        return sanitizeByteCharArraysOnly;
+    }
+
+    public void setSanitizeByteCharArraysOnly(final boolean sanitizeByteCharArraysOnly) {
+        this.sanitizeByteCharArraysOnly = sanitizeByteCharArraysOnly;
+    }
+
+    public boolean isSanitizeArraysOnly() {
+        return sanitizeArraysOnly;
+    }
+
+    public void setSanitizeArraysOnly(final boolean sanitizeArraysOnly) {
+        this.sanitizeArraysOnly = sanitizeArraysOnly;
+    }
+
+    public boolean isTarInput() {
+        return tarInput;
+    }
+
+    public void setTarInput(final boolean tarInput) {
+        this.tarInput = tarInput;
+    }
+
+    public String getSanitizationText() {
+        return StringEscapeUtils.unescapeJava(sanitizationText);
+    }
+
+    public void setSanitizationText(final String sanitizationText) {
+        // e.g. unescape user-supplied \\0 string (2 chars) to \0 string (1 char)
+        this.sanitizationText = StringEscapeUtils.unescapeJava(sanitizationText);
+    }
+
+    public boolean isForceMatchStringCoder() {
+        return forceMatchStringCoder;
+    }
+
+    public void setForceMatchStringCoder(final boolean forceMatchStringCoder) {
+        this.forceMatchStringCoder = forceMatchStringCoder;
+    }
+
+    public List<String> getExcludeStringFields() {
+        final List<String> list = excludeStringFields == null ? Collections.emptyList() : excludeStringFields;
+        return list.stream()
+                .map(StringUtils::trimToNull)
+                .filter(Objects::nonNull)
+                .filter(field -> field.contains("#"))
+                .map(field -> field.split(","))
+                .flatMap(Arrays::stream)
+                .collect(Collectors.toList());
+    }
+
+    public void setExcludeStringFields(final List<String> list) {
+        this.excludeStringFields = list;
+    }
+
+    private StringFieldMap getExcludeStringFieldMap() {
+        if (excludeStringFieldMap != null) {
+            return excludeStringFieldMap;
+        }
+        excludeStringFieldMap = new StringFieldMap();
+        getExcludeStringFields().forEach(excludeStringFieldMap::add);
+        return excludeStringFieldMap;
+    }
+
+    public boolean isExactClassWithExcludeStringField(final String className) {
+        return getExcludeStringFieldMap().map.containsKey(className);
+    }
+
+    public List<String> getExcludeStringFields(final String className) {
+        return getExcludeStringFieldMap().map.getOrDefault(className, Collections.emptyList());
+    }
+
+    @Override
+    public String toString() {
+        return reflectionToString(this, MULTI_LINE_STYLE);
+    }
+
+    private static class StringFieldMap {
+        private final Map<String, List<String>> map = new HashMap<>();
+
+        public void add(final String field) {
+            final String className = StringUtils.substringBefore(field, "#");
+            map.computeIfAbsent(className, key -> new ArrayList<>());
+            map.get(className).add(StringUtils.substringAfter(field, "#"));
+        }
+
+        @Override
+        public String toString() {
+            return reflectionToString(this, MULTI_LINE_STYLE);
+        }
+
+    }
+}

--- a/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeStreamFactory.java
+++ b/src/main/java/com/paypal/heapdumptool/sanitizer/SanitizeStreamFactory.java
@@ -58,10 +58,14 @@ public class SanitizeStreamFactory {
     }
 
     protected InputStream newInputStream(final Path inputFile) throws IOException {
-        final String name = inputFile.getFileName().toString();
-        return StringUtils.equalsAny(name, "-", "stdin", "0")
+        return isStdinInput()
                ? System.in
                : Files.newInputStream(inputFile);
+    }
+
+    public boolean isStdinInput() {
+        final String name = command.getInputFile().getFileName().toString();
+        return StringUtils.equalsAny(name, "-", "stdin", "0");
     }
 
     private static SanitizeCommand validate(final SanitizeCommand command) {

--- a/src/test/java/com/paypal/heapdumptool/capture/CaptureCommandProcessorTest.java
+++ b/src/test/java/com/paypal/heapdumptool/capture/CaptureCommandProcessorTest.java
@@ -4,6 +4,7 @@ import com.paypal.heapdumptool.fixture.ResourceTool;
 import com.paypal.heapdumptool.sanitizer.SanitizeCommandProcessor;
 import com.paypal.heapdumptool.utils.ProcessTool;
 import com.paypal.heapdumptool.utils.ProcessTool.ProcessResult;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang3.ArrayUtils;
@@ -130,13 +131,17 @@ public class CaptureCommandProcessorTest {
         processToolMock.when(() -> ProcessTool.run(cmd.maybeWithNsenter1("docker", "exec", "my-app", "jcmd", "55", "GC.heap_dump", tmpFile)))
                        .thenReturn(resultWith("docker-exec-jcmd-gc-heap-dump.txt"));
 
+        final Path heapDumpFileOnHost = FileUtils.getTempDirectory()
+                .toPath()
+                .resolve(Paths.get(tmpFile).getFileName().toString());
+
         final ProcessBuilder processBuilder = dockerCpProcess();
-        processToolMock.when(() -> ProcessTool.processBuilder(cmd.maybeWithNsenter1("docker", "cp", "my-app:" + tmpFile, "-")))
+        processToolMock.when(() -> ProcessTool.processBuilder(cmd.maybeWithNsenter1("docker", "cp", "my-app:" + tmpFile, heapDumpFileOnHost.toString())))
                        .thenReturn(processBuilder);
     }
 
     @FunctionalInterface
-    private static interface CmdFunction {
+    private interface CmdFunction {
         String[] maybeWithNsenter1(String... args);
     }
 

--- a/src/test/java/com/paypal/heapdumptool/capture/CaptureCommandTest.java
+++ b/src/test/java/com/paypal/heapdumptool/capture/CaptureCommandTest.java
@@ -12,6 +12,7 @@ public class CaptureCommandTest {
     public void testBean() {
         BeanVerifier.forClass(CaptureCommand.class)
                     .withSettings(settings -> settings.addOverridePropertyFactory(CaptureCommand::getBufferSize, () -> DataSize.ofMegabytes(5)))
+                    .withSettings(settings -> settings.addIgnoredPropertyName("excludeStringFields"))
                     .verifyGettersAndSetters();
     }
 

--- a/src/test/java/com/paypal/heapdumptool/sanitizer/SanitizeCommandProcessorTest.java
+++ b/src/test/java/com/paypal/heapdumptool/sanitizer/SanitizeCommandProcessorTest.java
@@ -6,17 +6,18 @@ import org.mockito.MockedConstruction;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Collections;
 
-import static com.paypal.heapdumptool.fixture.MockitoTool.firstInstance;
 import static com.paypal.heapdumptool.sanitizer.DataSize.ofBytes;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.verify;
 
-public class SanitizeCommandProcessorTest {
+class SanitizeCommandProcessorTest {
 
     private final HeapDumpSanitizer sanitizer = mock(HeapDumpSanitizer.class);
 
@@ -25,17 +26,18 @@ public class SanitizeCommandProcessorTest {
     private final SanitizeCommand command = new SanitizeCommand();
 
     @BeforeEach
-    public void beforeEach() throws IOException {
+    void beforeEach() throws IOException {
         doNothing().when(sanitizer).sanitize();
         doReturn(null).when(streamFactory).newInputStream();
         doReturn(null).when(streamFactory).newOutputStream();
 
         command.setInputFile(Paths.get("input"));
         command.setOutputFile(Paths.get("output"));
+        command.setExcludeStringFields(Collections.singletonList("none#none"));
     }
 
     @Test
-    public void testBufferSizeValidation() {
+    void testBufferSizeValidation() {
         command.setBufferSize(ofBytes(-1));
 
         assertThatThrownBy(() -> new SanitizeCommandProcessor(command))
@@ -44,15 +46,19 @@ public class SanitizeCommandProcessorTest {
     }
 
     @Test
-    public void testProcess() throws Exception {
+    void testProcess() throws Exception {
         final SanitizeCommandProcessor processor = new SanitizeCommandProcessor(command, streamFactory);
 
-        try (final MockedConstruction<HeapDumpSanitizer> mocked = mockConstruction(HeapDumpSanitizer.class)) {
-            final HeapDumpSanitizer sanitizer = new HeapDumpSanitizer();
-            doNothing().when(sanitizer).sanitize();
-
+        try (final MockedConstruction<HeapDumpSanitizer> mocked = mockConstruction(HeapDumpSanitizer.class, this::prepare)) {
             processor.process();
-            verify(firstInstance(mocked)).sanitize();
+            for (final HeapDumpSanitizer sanitizer : mocked.constructed()) {
+                verify(sanitizer, atLeastOnce()).sanitize();
+            }
         }
     }
+
+    private void prepare(final HeapDumpSanitizer mock, final MockedConstruction.Context context) throws Throwable {
+        doNothing().when(mock).sanitize();
+    }
+
 }

--- a/src/test/java/com/paypal/heapdumptool/sanitizer/SanitizeCommandTest.java
+++ b/src/test/java/com/paypal/heapdumptool/sanitizer/SanitizeCommandTest.java
@@ -12,6 +12,7 @@ public class SanitizeCommandTest {
     public void testBean() {
         BeanVerifier.forClass(SanitizeCommand.class)
                     .withSettings(settings -> settings.addOverridePropertyFactory(SanitizeCommand::getBufferSize, () -> ofMegabytes(5)))
+                    .withSettings(settings -> settings.addIgnoredPropertyName("excludeStringFields"))
                     .verifyGettersAndSetters();
     }
 

--- a/src/test/java/com/paypal/heapdumptool/sanitizer/example/ClassWithManyStaticFields.java
+++ b/src/test/java/com/paypal/heapdumptool/sanitizer/example/ClassWithManyStaticFields.java
@@ -2,6 +2,7 @@ package com.paypal.heapdumptool.sanitizer.example;
 
 public class ClassWithManyStaticFields {
 
+    public long unused = 1;
     public static long l0 = 0xCAFEBABE;
     public static long l1 = 0xCAFEBABE;
     public static long l2 = 0xCAFEBABE;


### PR DESCRIPTION
exclude, or do not sanitize, Thread.name and ThreadGroup.name fields by default